### PR TITLE
mkmf: Added subroutine for replacing '=' with '$(EQUALS)'

### DIFF
--- a/bin/mkmf
+++ b/bin/mkmf
@@ -31,8 +31,6 @@ use Getopt::Std;
 use Config;			# use to put in platform-specific stuff
 use vars qw( $opt_a $opt_c $opt_d $opt_f $opt_l $opt_m $opt_o $opt_p $opt_t $opt_v $opt_x $opt_I ); # declare these global to be shared with Getopt:Std
 
-EQUALS = =
-
 #subroutines
 sub ensureTrailingSlash {
 #ensure trailing slash on directory names
@@ -106,6 +104,7 @@ sub print_formatted_list{
 open MAKEFILE, ">$mkfile" or die "\aERROR opening file $mkfile for writing: $!\n";
 printf MAKEFILE "# Makefile created by %s $version\n\n", basename($0);
 print  MAKEFILE "SRCROOT = $opt_a\n\n" if $opt_a; # make abspath a variable
+print MAKEFILE "EQUALS = =\n\n"; # assign 'EQUALS' to '=' so directories with '=' don't break generation of the Makefile
 if ( $opt_c ) {
    $opt_c =~ s/\s+$//;
    if ( $Config{osname} eq 'aix' ) {

--- a/bin/mkmf
+++ b/bin/mkmf
@@ -31,10 +31,18 @@ use Getopt::Std;
 use Config;			# use to put in platform-specific stuff
 use vars qw( $opt_a $opt_c $opt_d $opt_f $opt_l $opt_m $opt_o $opt_p $opt_t $opt_v $opt_x $opt_I ); # declare these global to be shared with Getopt:Std
 
+EQUALS = =
+
 #subroutines
 sub ensureTrailingSlash {
 #ensure trailing slash on directory names
    local $/ = '/'; chomp @_[0]; @_[0] .= '/';
+}
+
+sub escapeEqualsSign {
+   my ( $string ) = @_[0];
+   
+   return $string =~ s/=/$(EQUALS)/
 }
 
 my $version = '$Id: mkmf,v 1.1.2.1 2013/12/18 17:47:54 Niki.Zadeh Exp $ ';

--- a/bin/mkmf
+++ b/bin/mkmf
@@ -36,13 +36,14 @@ EQUALS = =
 #subroutines
 sub ensureTrailingSlash {
 #ensure trailing slash on directory names
-   local $/ = '/'; chomp @_[0]; @_[0] .= '/';
+   local $/ = '/'; 
+   chomp @_[0]; 
+   @_[0] .= '/';
+   escapeEqualsSign(@_[0]);
 }
 
 sub escapeEqualsSign {
-   my ( $string ) = @_[0];
-   
-   return $string =~ s/=/$(EQUALS)/
+   @_[0] =~ s/=/\$\(EQUALS\)/;
 }
 
 my $version = '$Id: mkmf,v 1.1.2.1 2013/12/18 17:47:54 Niki.Zadeh Exp $ ';


### PR DESCRIPTION
Escaping all '=' with '$(EQUALS)' during makefile creation. 

Closes #9 