### PR TITLE
Mkmf escape fix

### DIFF
--- a/bin/mkmf
+++ b/bin/mkmf
@@ -467,6 +467,22 @@ if( $suffix eq '.a' ) {
    print MAKEFILE "$opt_p: \$(OBJ) $opt_l\n\t\$(LD) \$(OBJ) -o $opt_p $opt_l \$(LDFLAGS)\n";
 }
 close MAKEFILE;
+
+# Make a copy of the completed Makefile, read it back in, escape all relevant `=` signs
+# and write it back out
+rename($mkfile, $mkfile.'.bak');
+open(IN, '<' . $mkfile.'.bak') or die $!;
+open(OUT, '>' . $mkfile) or die $!;
+
+print OUT "EQUALS = =";
+
+while(<IN>) {
+   # Only escape '=' that aren't assignments (aka anything that spaces either side)
+   $_ =~ s/(?<! )=(?! )/\$\(EQUALS\)/g;
+   print OUT "$_";
+}
+close(IN);
+close(OUT);
 print " $mkfile is ready.\n";
 
 exec 'make', '-f', $mkfile if $opt_x;


### PR DESCRIPTION
`mkmf` fails to generate a valid Makefile when directories have `=` in them because it is a reserved word. 
This PR reads in the created Makefile and substitues all non-assignment `=` with `$(EQUALS)` (where `EQUALS = =`). 

Closes #9 !