### PR TITLE
Add support to build MOM5 with an external FMS and Generic Tracers using Spack

### DIFF
--- a/exp/ocean_compile.csh
+++ b/exp/ocean_compile.csh
@@ -9,7 +9,13 @@ if( $type == ACCESS-OM || $type == ACCESS-CM || $type == ACCESS-OM-BGC || $type 
     if( $type ==  ACCESS-OM-BGC ) then
         set srcList = ( $srcList mom5/ocean_csiro_bgc )
     else if ( $type ==  ACCESS-OM || $type == ACCESS-ESM ) then
-        set srcList = ( $srcList mom5/ocean_bgc access/generic_tracers/generic_tracers access/generic_tracers/mocsy/src )
+
+        if ( ! $?SPACK_GTRACERS_EXTERNAL ) then
+            set srcList = ( $srcList mom5/ocean_bgc access/generic_tracers/generic_tracers access/generic_tracers/mocsy/src )
+        else
+            set srcList = ( $srcList mom5/ocean_bgc )
+        endif
+
     endif
     mkdir -p $executable:h:h/$type/$lib_name
     cd $executable:h:h/$type/$lib_name


### PR DESCRIPTION
* Ideally we should use a better build system. However, this appears to be the
  least intrusive and simple way to introduce this feature.