### PR TITLE
mppnccombine.c: move inline function above the calls to the function.

### DIFF
--- a/src/postprocessing/mppnccombine/mppnccombine.c
+++ b/src/postprocessing/mppnccombine/mppnccombine.c
@@ -134,6 +134,12 @@
 #  define DEFAULT_SHUFFLE 1
 #endif
 
+inline int min(int a, int b)
+{
+  if (a<b) return a;
+  return b;
+}
+
 /* Information structure for a file */
 struct fileinfo
   {
@@ -721,12 +727,6 @@ void usage()
    printf("otherwise.\n");
   }
 
-
-inline int min(int a, int b)
-{
-  if (a<b) return a;
-  return b;
-}
 
 /* Open an input file and get some information about it, define the   */
 /* structure of the output file if necessary, prepare to copy all the */


### PR DESCRIPTION
* Needed to support oneapi 2025 compiler.

```
/tmp/root/spack-stage/spack-stage-mom5-git.2023.11.09_access-om2-ug23iu66zow46gga3b7jkd2e25sg7i3l/spack-src/src/postprocessing/mppnccombine/mppnccombine.c:463:39: error: call to undeclared function 'min'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  463 |                  for (r=block * bf; r<min((block+1)*bf, nrecs); r++)
      |                                       ^
```