### PR TITLE
Fixing divide-by-zero runtime error when compiled with oneAPI

### DIFF
--- a/src/mom5/ocean_core/ocean_topog.F90
+++ b/src/mom5/ocean_core/ocean_topog.F90
@@ -358,7 +358,7 @@ subroutine ocean_topog_init (Domain, Grid, grid_file, vert_coordinate_type)
   Grid%htr = 0.0 
   do j=jsd,jed
      do i=isd,ied
-        if(Grid%kmt(i,j) > 0) then    
+        if(Grid%ht(i,j) > 0) then
             Grid%htr(i,j) = 1.0/Grid%ht(i,j)
         endif
      enddo


### PR DESCRIPTION
When compiled with oneAPI, @dougiesquire found that there was a divide-by-zero - as noted in this [comment](https://github.com/ACCESS-NRI/access-om2-configs/pull/167#issuecomment-2712089978)


Numerically this is the appropriate fix, but someone with knowledge of the code should confirm/clarify why the other check was there in the first place (as in, why  `%kmt > 0` check was being used instead of `%ht > 0` when calculating the reciprocal of `%ht`)