### PR TITLE
Build-CI: fix typo in logic for finding manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # Find all relevant files under .github/build-ci/manifests/pr/<base_ref>
         # then output them as a JSON array (minus the last comma)
         run: |
-          files=$(find .github/build-ci/manifests/pr/${{ github.event.pull_request.base.ref || github.event.base_ref }} -iname '*.j2' -printf '"%p",')
+          files=$(find .github/build-ci/manifests/pr/${{ github.event.pull_request.base.ref || github.event.push.base_ref }} -iname '*.j2' -printf '"%p",')
           echo "matrix=[${files%,}]" >> $GITHUB_OUTPUT
   ci:
     name: CI

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Test MOM5 compilation](https://github.com/ACCESS-NRI/MOM5/actions/workflows/test-build.yml/badge.svg?branch=master)](https://github.com/ACCESS-NRI/MOM5/actions/workflows/test-build.yml)
+[![Build](https://github.com/ACCESS-NRI/MOM5/actions/workflows/ci.yml/badge.svg)](https://github.com/ACCESS-NRI/MOM5/actions/workflows/ci.yml)
+[![Scheduled Build](https://github.com/ACCESS-NRI/MOM5/actions/workflows/scheduled.yml/badge.svg)](https://github.com/ACCESS-NRI/MOM5/actions/workflows/scheduled.yml)
 
 # ACCESS-NRI Fork of Modular Ocean Model version 5 (MOM5)
 


### PR DESCRIPTION
Of course, there was a typo. Small fix to changes made in #53 