### PR TITLE
Build-CI: fix logic for finding branch-specific manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         # Find all relevant files under .github/build-ci/manifests/pr/<base_ref>
         # then output them as a JSON array (minus the last comma)
         run: |
-          files=$(find .github/build-ci/manifests/pr/${{ github.event.pull_request.base.ref || github.event.push.base_ref }} -iname '*.j2' -printf '"%p",')
+          files=$(find .github/build-ci/manifests/pr/${{ github.event.pull_request.base.ref || github.ref_name }} -iname '*.j2' -printf '"%p",')
           echo "matrix=[${files%,}]" >> $GITHUB_OUTPUT
   ci:
     name: CI


### PR DESCRIPTION
And again. Ref #53, #54 