### PR TITLE
Build CI: Fix scheduled testing of access-esm1.5 branch

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,6 +12,8 @@ jobs:
       scheduled_ref: ${{ steps.get-scheduled-ref.outputs.scheduled_ref }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: 'access-esm1.5'
 
       - name: Set up matrix
         id: set-matrix


### PR DESCRIPTION
Scheduled testing of the access-esm1.5 branch is failing because `scheduled_ref` is resolving to `origin/access-esm1.5` rather than the latest commit on that branch. @CodeGat thinks this is because there isn't enough history being retrieved by the checkout action in the `pre-access-esm1.5` job. The fix should be to checkout the `access-esm1.5` branch in that job. That is what is done in this PR.