### PR TITLE
Replace `{{ scheduled_ref }}` with `{{ ref }}` due to explicit `inputs.ref` value

### DIFF
--- a/.github/build-ci/manifests/scheduled/gcc_mom_access-esm1.5.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/gcc_mom_access-esm1.5.spack.yaml.j2
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - mom5@git.{{ scheduled_ref }}=access-esm1.5
+  - mom5@git.{{ ref }}=access-esm1.5
   packages:
     oasis3-mct:
       require:

--- a/.github/build-ci/manifests/scheduled/intel_mom_access-esm1.5.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/intel_mom_access-esm1.5.spack.yaml.j2
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - mom5@git.{{ scheduled_ref }}=access-esm1.5
+  - mom5@git.{{ ref }}=access-esm1.5
   packages:
     oasis3-mct:
       require:

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.5.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.5.spack.yaml.j2
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - mom5@git.{{ scheduled_ref }}=access-esm1.5
+  - mom5@git.{{ ref }}=access-esm1.5
   packages:
     oasis3-mct:
       require:


### PR DESCRIPTION
Replacing all the `{{ scheduled_ref }}`s with `{{ ref }}` due to https://github.com/ACCESS-NRI/MOM5/pull/63/commits/cfeb008f5e6cbe816f7ada8841c800c4efd66c26
