### PR TITLE
`build-ci v3`: Update Infra For `spack v1`

### DIFF
--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,7 +1,7 @@
 {
-  "intel_compiler": "intel@2021.10.0",
-  "gcc_compiler": "gcc@13.2.0",
-  "oneapi_compiler": "oneapi@2025.2.0",
+  "intel_compiler_version": "2021.10.0",
+  "gcc_compiler_version": "13.2.0",
+  "oneapi_compiler_version": "2025.2.0",
   "cice5_version": "2026.01.000",
   "um_version": "git.2026.02.000=access-esm1.6",
   "cable_version": "2025.11.000",

--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -6,7 +6,7 @@
   "um_version": "git.2026.02.000=access-esm1.6",
   "cable_version": "2025.11.000",
   "gcom4_version": "git.2025.08.000=access-esm1.5",
-  "libaccessom2_version": "git.2025.05.001=access-om2",
+  "libaccessom2_version": "git.2026.02.000=access-om2",
   "oasis3_mct_version_esm1p6": "5.2",
   "oasis3_mct_version_om2": "git.2025.03.001=stable",
   "netcdf_c_version": "4.9.2",
@@ -14,6 +14,6 @@
   "parallelio_version": "2.6.8",
   "openmpi_version": "5.0.8",
   "access_fms_version": "git.mom5-2025.08.000=mom5",
-  "access_generic_tracers_version": "2026.01.000",
+  "access_generic_tracers_version": "2026.02.000",
   "access_mocsy_version": "2025.07.002"
 }

--- a/.github/build-ci/manifests/pr/gcc_access-esm1.6.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/gcc_access-esm1.6.spack.yaml.j2
@@ -40,9 +40,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    gcc:
+      require:
+      - '@{{ gcc_compiler_version }}'
     all:
       require:
-      - '%{{ gcc_compiler }} target=x86_64'
+      - '%access_gcc'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/pr/gcc_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/gcc_access-om2.spack.yaml.j2
@@ -9,7 +9,6 @@ spack:
       require:
       - '@{{ cice5_version }}'
       - 'io_type=PIO build_system=cmake'
-      - 'nxglob=360 nyglob=300 blckx=15 blcky=300 mxblcks=1' # grid size and block size
     libaccessom2:
       require:
       - '@{{ libaccessom2_version }}'

--- a/.github/build-ci/manifests/pr/gcc_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/gcc_access-om2.spack.yaml.j2
@@ -37,9 +37,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    gcc:
+      require:
+      - '@{{ gcc_compiler_version }}'
     all:
       require:
-      - '%{{ gcc_compiler }} target=x86_64'
+      - '%access_gcc'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/pr/intel_access-esm1.6.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/intel_access-esm1.6.spack.yaml.j2
@@ -40,9 +40,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
     all:
       require:
-      - '%{{ intel_compiler }} target=x86_64'
+      - '%access_intel'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/pr/intel_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/intel_access-om2.spack.yaml.j2
@@ -37,9 +37,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
     all:
       require:
-      - '%{{ intel_compiler }} target=x86_64'
+      - '%access_intel'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/pr/intel_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/intel_access-om2.spack.yaml.j2
@@ -9,7 +9,6 @@ spack:
       require:
       - '@{{ cice5_version }}'
       - 'io_type=PIO build_system=cmake'
-      - 'nxglob=360 nyglob=300 blckx=15 blcky=300 mxblcks=1' # grid size and block size
     libaccessom2:
       require:
       - '@{{ libaccessom2_version }}'

--- a/.github/build-ci/manifests/pr/oneapi_access-esm1.6.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/oneapi_access-esm1.6.spack.yaml.j2
@@ -40,9 +40,6 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    gcc-runtime:
-      require:
-      - '%gcc'
     intel-oneapi-compilers:
       require:
       - '@{{ oneapi_compiler_version }}'

--- a/.github/build-ci/manifests/pr/oneapi_access-esm1.6.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/oneapi_access-esm1.6.spack.yaml.j2
@@ -43,9 +43,13 @@ spack:
     gcc-runtime:
       require:
       - '%gcc'
+    intel-oneapi-compilers:
+      require:
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target=x86_64'
+      - '%access_oneapi'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/pr/oneapi_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/oneapi_access-om2.spack.yaml.j2
@@ -37,9 +37,6 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    gcc-runtime:
-      require:
-      - '%gcc'
     intel-oneapi-compilers:
       require:
       - '@{{ oneapi_compiler_version }}'

--- a/.github/build-ci/manifests/pr/oneapi_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/oneapi_access-om2.spack.yaml.j2
@@ -40,9 +40,13 @@ spack:
     gcc-runtime:
       require:
       - '%gcc'
+    intel-oneapi-compilers:
+      require:
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target=x86_64'
+      - '%access_oneapi'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/pr/oneapi_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/oneapi_access-om2.spack.yaml.j2
@@ -9,7 +9,6 @@ spack:
       require:
       - '@{{ cice5_version }}'
       - 'io_type=PIO build_system=cmake'
-      - 'nxglob=360 nyglob=300 blckx=15 blcky=300 mxblcks=1' # grid size and block size
     libaccessom2:
       require:
       - '@{{ libaccessom2_version }}'

--- a/.github/build-ci/manifests/scheduled/gcc_mom-sis.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/gcc_mom-sis.spack.yaml.j2
@@ -11,9 +11,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    gcc:
+      require:
+      - '@{{ gcc_compiler_version }}'
     all:
       require:
-      - '%{{ gcc_compiler }} target=x86_64'
+      - '%access_gcc'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/gcc_mom-solo.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/gcc_mom-solo.spack.yaml.j2
@@ -11,9 +11,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    gcc:
+      require:
+      - '@{{ gcc_compiler_version }}'
     all:
       require:
-      - '%{{ gcc_compiler }} target=x86_64'
+      - '%access_gcc'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/gcc_mom_access-esm1.6.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/gcc_mom_access-esm1.6.spack.yaml.j2
@@ -23,9 +23,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    gcc:
+      require:
+      - '@{{ gcc_compiler_version }}'
     all:
       require:
-      - '%{{ gcc_compiler }} target=x86_64'
+      - '%access_gcc'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/gcc_mom_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/gcc_mom_access-om2.spack.yaml.j2
@@ -28,9 +28,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    gcc:
+      require:
+      - '@{{ gcc_compiler_version }}'
     all:
       require:
-      - '%{{ gcc_compiler }} target=x86_64'
+      - '%access_gcc'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/gcc_mom_legacy-access-om2-bgc.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/gcc_mom_legacy-access-om2-bgc.spack.yaml.j2
@@ -28,9 +28,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    gcc:
+      require:
+      - '@{{ gcc_compiler_version }}'
     all:
       require:
-      - '%{{ gcc_compiler }} target=x86_64'
+      - '%access_gcc'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/intel_mom-sis.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/intel_mom-sis.spack.yaml.j2
@@ -11,9 +11,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
     all:
       require:
-      - '%{{ intel_compiler }} target=x86_64'
+      - '%access_intel'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/intel_mom-solo.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/intel_mom-solo.spack.yaml.j2
@@ -11,9 +11,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
     all:
       require:
-      - '%{{ intel_compiler }} target=x86_64'
+      - '%access_intel'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/intel_mom_access-esm1.6.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/intel_mom_access-esm1.6.spack.yaml.j2
@@ -23,9 +23,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
     all:
       require:
-      - '%{{ intel_compiler }} target=x86_64'
+      - '%access_intel'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/intel_mom_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/intel_mom_access-om2.spack.yaml.j2
@@ -28,9 +28,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
     all:
       require:
-      - '%{{ intel_compiler }} target=x86_64'
+      - '%access_intel'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/intel_mom_legacy-access-om2-bgc.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/intel_mom_legacy-access-om2-bgc.spack.yaml.j2
@@ -28,9 +28,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
     all:
       require:
-      - '%{{ intel_compiler }} target=x86_64'
+      - '%access_intel'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/oneapi_mom-sis.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom-sis.spack.yaml.j2
@@ -14,9 +14,13 @@ spack:
     gcc-runtime:
       require:
       - '%gcc'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target=x86_64'
+      - '%access_oneapi'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/oneapi_mom-sis.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom-sis.spack.yaml.j2
@@ -11,9 +11,6 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    gcc-runtime:
-      require:
-      - '%gcc'
     intel-oneapi-compilers-classic:
       require:
       - '@{{ oneapi_compiler_version }}'

--- a/.github/build-ci/manifests/scheduled/oneapi_mom-solo.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom-solo.spack.yaml.j2
@@ -14,9 +14,13 @@ spack:
     gcc-runtime:
       require:
       - '%gcc'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target=x86_64'
+      - '%access_oneapi'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/oneapi_mom-solo.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom-solo.spack.yaml.j2
@@ -11,9 +11,6 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    gcc-runtime:
-      require:
-      - '%gcc'
     intel-oneapi-compilers-classic:
       require:
       - '@{{ oneapi_compiler_version }}'

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.6.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.6.spack.yaml.j2
@@ -23,9 +23,6 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    gcc-runtime:
-      require:
-      - '%gcc'
     intel-oneapi-compilers-classic:
       require:
       - '@{{ oneapi_compiler_version }}'

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.6.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.6.spack.yaml.j2
@@ -26,9 +26,13 @@ spack:
     gcc-runtime:
       require:
       - '%gcc'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target=x86_64'
+      - '%access_oneapi'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_access-om2.spack.yaml.j2
@@ -31,9 +31,13 @@ spack:
     gcc-runtime:
       require:
       - '%gcc'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target=x86_64'
+      - '%access_oneapi'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_access-om2.spack.yaml.j2
@@ -28,9 +28,6 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    gcc-runtime:
-      require:
-      - '%gcc'
     intel-oneapi-compilers-classic:
       require:
       - '@{{ oneapi_compiler_version }}'

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_legacy-access-om2-bgc.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_legacy-access-om2-bgc.spack.yaml.j2
@@ -31,9 +31,13 @@ spack:
     gcc-runtime:
       require:
       - '%gcc'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target=x86_64'
+      - '%access_oneapi'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_legacy-access-om2-bgc.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_legacy-access-om2-bgc.spack.yaml.j2
@@ -28,9 +28,6 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    gcc-runtime:
-      require:
-      - '%gcc'
     intel-oneapi-compilers-classic:
       require:
       - '@{{ oneapi_compiler_version }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
       # builtin-spack-packages-ref: main
       # access-spack-packages-ref: api-v2
       # spack-config-ref: main
-      # spack-ref: releases/v1.0
+      # spack-ref: releases/v1.1
     secrets:
       spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,7 @@ jobs:
       spack-manifest-path: ${{ matrix.file }}
       spack-manifest-data-path: .github/build-ci/data/standard.json
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
-      # builtin-spack-packages-ref: main
-      # access-spack-packages-ref: api-v2
-      # spack-config-ref: main
-      # spack-ref: releases/v1.1
+      # Default args (including explicit spack/spack-packages/spack-config versions)
+      # are specified in https://github.com/ACCESS-NRI/build-ci/tree/v3/.github/workflows#inputs
     secrets:
       spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,14 @@ jobs:
         exclude:
         # TODO: Remove this exclusion once https://github.com/ACCESS-NRI/GCOM4/issues/15 is fixed
         - file: .github/build-ci/manifests/pr/gcc_access-esm1.6.spack.yaml.j2
-    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-path: ${{ matrix.file }}
       spack-manifest-data-path: .github/build-ci/data/standard.json
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
-      # spack-packages-ref: main
+      # builtin-spack-packages-ref: main
+      # access-spack-packages-ref: api-v2
       # spack-config-ref: main
-      # spack-ref: releases/v0.22
+      # spack-ref: releases/v1.0
     secrets:
       spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}


### PR DESCRIPTION
References issue ACCESS-NRI/build-ci#231 and PR ACCESS-NRI/build-ci#253
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!IMPORTANT]
> This PR is a major update to the infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for CI using `spack < 1.0`. They will still get bug fixes and non-breaking features if required.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-ci v2`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-ci v3`.

## Background

We are looking to transition `build-ci` to `v3`! This is due to a migration to `spack v1.X`, from `v0.X`, which offers many bug fixes, features, and optimisations.

One of these changes is the splitting of spacks core codebase from the builtin spack-packages repository, which means that we have another lever to tweak for our builds: the version of `spack`, `spack-config`, our `spack-packages` and the (new!) builtin `spack-packages`.

Since we want to leave open the possibility of forking the builtin `spack-packages`, we have also decided to rename `ACCESS-NRI/spack-packages` to `ACCESS-NRI/access-spack-packages`. See ACCESS-NRI/access-spack-packages#295 for more info.

Therefore this is a major version update, as there are the following changes to the inputs (and analogous changes to the workflow outputs):

* Deleted the optional `spack-packages-ref` input, which defaulted to `main` (in future, `api-v1`).
* Added the optional `access-spack-packages-ref` input, which defaults to the `api-v2` branch.
* Added the optional `builtin-spack-packages-ref` input, which defaults to the `main` branch.

This means that:

* If you want to use `container-image-version: :rocky-0.22-*`, or `spack-ref` < `releases/1.0`, you must stay on `v2` due to the input changes.
* If you want to use `container-image-version: :rocky-1.*-*`, or `spack-ref` >= `releases/1.0`, you must migrate to `v3` due to the input changes.

It is possible to test across these versions of `spack` if required, via a mix of workflow versions. Ask @CodeGat if you need this functionality.

## Features

The main new features include:

* **Proper Spack v1 Support**: Users now can tweak both the builtin `spack-packages` repository, as well as our own `access-spack-packages` repository. All of the bugfixes, features and optimisations added since `0.22` are available to us for future inclusion into `build-ci`.

## Prerequisites for Merging

- [x] Update `build-ci` entrypoints to `v3` (this PR!)
- [x] Determine if a specific `builtin-spack-packages-ref` is required
- [x] Determine if the added `access-spack-packages-ref` is appropriate
- [x] Validate if maintainers want to move to `spack v1` over `spack v0.22`
