### PR TITLE
`build-ci v3`: Update Infra For `spack v1` (ESM1.5)

### DIFF
--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,7 +1,7 @@
 {
-  "intel_compiler": "intel@2021.10.0",
-  "gcc_compiler": "gcc@13.2.0",
-  "oneapi_compiler": "oneapi@2025.2.0",
+  "intel_compiler_version": "2021.10.0",
+  "gcc_compiler_version": "13.2.0",
+  "oneapi_compiler_version": "2025.2.0",
   "cice4_version": "git.access-esm1.5-2025.04.001=access-esm1.5",
   "um_version": "git.2024.10.17=access-esm1.5",
   "gcom4_version": "git.2024.05.28=access-esm1.5",

--- a/.github/build-ci/manifests/pr/intel_access-esm1.5.spack.yaml.j2
+++ b/.github/build-ci/manifests/pr/intel_access-esm1.5.spack.yaml.j2
@@ -26,9 +26,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
     all:
       require:
-      - '%{{ intel_compiler }} target=x86_64'
+      - '%access_intel'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/gcc_mom_access-esm1.5.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/gcc_mom_access-esm1.5.spack.yaml.j2
@@ -14,9 +14,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    gcc:
+      require:
+      - '@{{ gcc_compiler_version }}'
     all:
       require:
-      - '%{{ gcc_compiler }} target=x86_64'
+      - '%access_gcc'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/intel_mom_access-esm1.5.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/intel_mom_access-esm1.5.spack.yaml.j2
@@ -14,9 +14,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
+    intel-oneapi-compilers-classic:
+      require:
+      - '@{{ intel_compiler_version }}'
     all:
       require:
-      - '%{{ intel_compiler }} target=x86_64'
+      - '%access_intel'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.5.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.5.spack.yaml.j2
@@ -14,12 +14,13 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    gcc-runtime:
+    intel-oneapi-compilers-classic:
       require:
-      - '%gcc'
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target=x86_64'
+      - '%access_oneapi'
+      - 'target=x86_64'
   concretizer:
     unify: false
   view: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,6 @@ jobs:
       # builtin-spack-packages-ref: main
       # access-spack-packages-ref: api-v2
       # spack-config-ref: main
-      # spack-ref: releases/v1.0
+      # spack-ref: releases/v1.1
     secrets:
       spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,14 @@ jobs:
       max-parallel: 4
       matrix:
         file: ${{ fromJson(needs.pre-ci.outputs.matrix) }}
-    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-path: ${{ matrix.file }}
       spack-manifest-data-path: .github/build-ci/data/standard.json
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
-      # spack-packages-ref: main
+      # builtin-spack-packages-ref: main
+      # access-spack-packages-ref: api-v2
       # spack-config-ref: main
-      # spack-ref: releases/v0.22
+      # spack-ref: releases/v1.0
     secrets:
       spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
       spack-manifest-path: ${{ matrix.file }}
       spack-manifest-data-path: .github/build-ci/data/standard.json
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
-      # builtin-spack-packages-ref: main
-      # access-spack-packages-ref: api-v2
-      # spack-config-ref: main
-      # spack-ref: releases/v1.1
+      # Default args (including explicit spack/spack-packages/spack-config versions)
+      # are specified in https://github.com/ACCESS-NRI/build-ci/tree/v3/.github/workflows#inputs
     secrets:
       spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}


### PR DESCRIPTION
References issue ACCESS-NRI/build-ci#231 and PR ACCESS-NRI/build-ci#253
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!IMPORTANT]
> This PR is a major update to the infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for CI using `spack < 1.0`. They will still get bug fixes and non-breaking features if required.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-ci v2`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-ci v3`.

## Background

We are looking to transition `build-ci` to `v3`! This is due to a migration to `spack v1.X`, from `v0.X`, which offers many bug fixes, features, and optimisations.

One of these changes is the splitting of spacks core codebase from the builtin spack-packages repository, which means that we have another lever to tweak for our builds: the version of `spack`, `spack-config`, our `spack-packages` and the (new!) builtin `spack-packages`.

Since we want to leave open the possibility of forking the builtin `spack-packages`, we have also decided to rename `ACCESS-NRI/spack-packages` to `ACCESS-NRI/access-spack-packages`. See ACCESS-NRI/access-spack-packages#295 for more info.

Therefore this is a major version update, as there are the following changes to the inputs (and analogous changes to the workflow outputs):

* Deleted the optional `spack-packages-ref` input, which defaulted to `main` (in future, `api-v1`).
* Added the optional `access-spack-packages-ref` input, which defaults to the `api-v2` branch.
* Added the optional `builtin-spack-packages-ref` input, which defaults to the `main` branch.

This means that:

* If you want to use `container-image-version: :rocky-0.22-*`, or `spack-ref` < `releases/1.0`, you must stay on `v2` due to the input changes.
* If you want to use `container-image-version: :rocky-1.*-*`, or `spack-ref` >= `releases/1.0`, you must migrate to `v3` due to the input changes.

It is possible to test across these versions of `spack` if required, via a mix of workflow versions. Ask @CodeGat if you need this functionality.

## Features

The main new features include:

* **Proper Spack v1 Support**: Users now can tweak both the builtin `spack-packages` repository, as well as our own `access-spack-packages` repository. All of the bugfixes, features and optimisations added since `0.22` are available to us for future inclusion into `build-ci`.

## Prerequisites for Merging

- [x] Update `build-ci` entrypoints to `v3` (this PR!)
- [x] Determine if a specific `builtin-spack-packages-ref` is required
- [x] Determine if the added `access-spack-packages-ref` is appropriate
- [x] Validate if maintainers want to move to `spack v1` over `spack v0.22`
