### PR TITLE
Initialize `Ocean_state` pointer to null() in access drivers.

### DIFF
--- a/src/access/accesscm_coupler/ocean_solo.F90
+++ b/src/access/accesscm_coupler/ocean_solo.F90
@@ -161,7 +161,7 @@ program main
   implicit none
 
   type (ocean_public_type)               :: Ocean_sfc          
-  type (ocean_state_type),       pointer :: Ocean_state
+  type (ocean_state_type),       pointer :: Ocean_state => null()
   type(ice_ocean_boundary_type), target  :: Ice_ocean_boundary
   type(coupler_2d_bc_type),      target  :: Atm_fields
 

--- a/src/access/accessom_coupler/ocean_solo.F90
+++ b/src/access/accessom_coupler/ocean_solo.F90
@@ -118,7 +118,7 @@ program main
   implicit none
 
   type (ocean_public_type)               :: Ocean_sfc
-  type (ocean_state_type),       pointer :: Ocean_state
+  type (ocean_state_type),       pointer :: Ocean_state => null()
   type(ice_ocean_boundary_type), target  :: Ice_ocean_boundary
   type(coupler_2d_bc_type),      target  :: Atm_fields
   type(accessom2_type) :: accessom2


### PR DESCRIPTION
This PR initializes the `Ocean_state` pointers to null() in the access drivers. This ensures the pointer has a defined association status on declaration, avoiding undefined behavior when using GCC.

