### PR TITLE
build-ci/manifests/*/oneapi*: should be intel-oneapi-compilers

### DIFF
--- a/.github/build-ci/manifests/scheduled/oneapi_mom-sis.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom-sis.spack.yaml.j2
@@ -11,7 +11,7 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    intel-oneapi-compilers-classic:
+    intel-oneapi-compilers:
       require:
       - '@{{ oneapi_compiler_version }}'
     all:

--- a/.github/build-ci/manifests/scheduled/oneapi_mom-solo.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom-solo.spack.yaml.j2
@@ -11,7 +11,7 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    intel-oneapi-compilers-classic:
+    intel-oneapi-compilers:
       require:
       - '@{{ oneapi_compiler_version }}'
     all:

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.6.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.6.spack.yaml.j2
@@ -23,7 +23,7 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    intel-oneapi-compilers-classic:
+    intel-oneapi-compilers:
       require:
       - '@{{ oneapi_compiler_version }}'
     all:

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_access-om2.spack.yaml.j2
@@ -28,7 +28,7 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    intel-oneapi-compilers-classic:
+    intel-oneapi-compilers:
       require:
       - '@{{ oneapi_compiler_version }}'
     all:

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_legacy-access-om2-bgc.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_legacy-access-om2-bgc.spack.yaml.j2
@@ -28,7 +28,7 @@ spack:
     openmpi:
       require:
       - '@{{ openmpi_version }}'
-    intel-oneapi-compilers-classic:
+    intel-oneapi-compilers:
       require:
       - '@{{ oneapi_compiler_version }}'
     all:


### PR DESCRIPTION
In PR https://github.com/ACCESS-NRI/access-spack-packages/pull/452 CI we see the following error:
```
Run . /opt/spack/share/spack/setup-env.sh
==> Created environment default in: /opt/runner/environments/default
==> Activate with: spack env activate default
==> Activated default environment in /opt/runner/environments/default
==> Compilers have been configured automatically from PATH inspection
==> Error: Version requirement 2025.2.0 on intel-oneapi-compilers-classic for intel-oneapi-compilers-classic cannot match any known version from package.py or externals
==> Starting concretization
Error: Process completed with exit code 1.
```