### PR TITLE
build-ci/manifests/scheduled: remove makefile tests

### DIFF
--- a/.github/build-ci/manifests/scheduled/gcc_mom_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/gcc_mom_access-om2.spack.yaml.j2
@@ -1,8 +1,6 @@
 spack:
   specs:
-  - matrix:
-    - ['mom5@git.{{ ref }}=access-om2']
-    - ['build_system=cmake', 'build_system=makefile']
+  - 'mom5@git.{{ ref }}=access-om2'
   packages:
     libaccessom2:
       require:

--- a/.github/build-ci/manifests/scheduled/gcc_mom_legacy-access-om2-bgc.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/gcc_mom_legacy-access-om2-bgc.spack.yaml.j2
@@ -1,8 +1,6 @@
 spack:
   specs:
-  - matrix:
-    - ['mom5@git.{{ ref }}=legacy-access-om2-bgc']
-    - ['build_system=cmake', 'build_system=makefile']
+  - 'mom5@git.{{ ref }}=legacy-access-om2-bgc'
   packages:
     libaccessom2:
       require:

--- a/.github/build-ci/manifests/scheduled/intel_mom_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/intel_mom_access-om2.spack.yaml.j2
@@ -1,8 +1,6 @@
 spack:
   specs:
-  - matrix:
-    - ['mom5@git.{{ ref }}=access-om2']
-    - ['build_system=cmake', 'build_system=makefile']
+  - 'mom5@git.{{ ref }}=access-om2'
   packages:
     libaccessom2:
       require:

--- a/.github/build-ci/manifests/scheduled/intel_mom_legacy-access-om2-bgc.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/intel_mom_legacy-access-om2-bgc.spack.yaml.j2
@@ -1,8 +1,6 @@
 spack:
   specs:
-  - matrix:
-    - ['mom5@git.{{ ref }}=legacy-access-om2-bgc']
-    - ['build_system=cmake', 'build_system=makefile']
+  -  'mom5@git.{{ ref }}=legacy-access-om2-bgc'
   packages:
     libaccessom2:
       require:

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_access-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_access-om2.spack.yaml.j2
@@ -1,8 +1,6 @@
 spack:
   specs:
-  - matrix:
-    - ['mom5@git.{{ ref }}=access-om2']
-    - ['build_system=cmake', 'build_system=makefile']
+  - 'mom5@git.{{ ref }}=access-om2'
   packages:
     libaccessom2:
       require:

--- a/.github/build-ci/manifests/scheduled/oneapi_mom_legacy-access-om2-bgc.spack.yaml.j2
+++ b/.github/build-ci/manifests/scheduled/oneapi_mom_legacy-access-om2-bgc.spack.yaml.j2
@@ -1,8 +1,6 @@
 spack:
   specs:
-  - matrix:
-    - ['mom5@git.{{ ref }}=legacy-access-om2-bgc']
-    - ['build_system=cmake', 'build_system=makefile']
+  - 'mom5@git.{{ ref }}=legacy-access-om2-bgc'
   packages:
     libaccessom2:
       require:


### PR DESCRIPTION
PR https://github.com/ACCESS-NRI/access-spack-packages/pull/443 removes makefile support. We need to update the tests.