### PR TITLE
Use correct index for diagnostic temp when applying the cmip unit offset

### DIFF
--- a/src/mom5/ocean_tracers/ocean_tracer.F90
+++ b/src/mom5/ocean_tracers/ocean_tracer.F90
@@ -4101,7 +4101,7 @@ subroutine send_tracer_diagnostics(Time, T_prog, T_diag, Thickness, Dens, use_bl
   do n=1,num_diag_tracers
 
      if(id_diag(n) > 0) then 
-         if(n==index_temp) then 
+         if(n==index_diag_temp) then
              wrk1(:,:,:) = 0.0
              do k=1,nk
                 do j=jsc,jec
@@ -4117,7 +4117,7 @@ subroutine send_tracer_diagnostics(Time, T_prog, T_diag, Thickness, Dens, use_bl
      endif
 
      if (id_diag_surf_tracer(n) > 0) then 
-         if(n==index_temp) then 
+         if(n==index_diag_temp) then
              wrk1_2d(:,:) = 0.0
              do j=jsc,jec
                 do i=isc,iec
@@ -4132,7 +4132,7 @@ subroutine send_tracer_diagnostics(Time, T_prog, T_diag, Thickness, Dens, use_bl
      endif
 
      if (id_diag_surf_tracer_sq(n) > 0) then
-         if(n==index_temp) then 
+         if(n==index_diag_temp) then
              wrk1_2d(:,:) = 0.0
              do j=jsc,jec
                 do i=isc,iec


### PR DESCRIPTION
This PR fixes the `pot_temp`/`con_temp` diagnostic tracer being mislabeled with units of Kelvin when `cmip_units=.true.` and `cmip_version<=5`.

Closes #84 