### PR TITLE
Updated scheduled.yml to use build-ci@v3

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,7 +11,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       scheduled_ref: ${{ steps.get-scheduled-ref.outputs.scheduled_ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: 'access-esm1.5'
 
@@ -39,15 +39,14 @@ jobs:
         # TODO: Remove this exclusion once https://github.com/ACCESS-NRI/oasis3-mct/issues/41 is fixed
         - file: .github/build-ci/manifests/scheduled/gcc_mom_access-esm1.5.spack.yaml.j2
         - file: .github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.5.spack.yaml.j2
-    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-path: ${{ matrix.file }}
       spack-manifest-data-path: .github/build-ci/data/standard.json
       ref: ${{ needs.pre-access-esm1p5.outputs.scheduled_ref }}
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
-      # spack-packages-ref: main
-      # spack-config-ref: main
-      # spack-ref: releases/v0.22
+      # Default args (including explicit spack/spack-packages/spack-config versions)
+      # are specified in https://github.com/ACCESS-NRI/build-ci/tree/v3/.github/workflows#inputs
 
   pre-master:
     name: Pre-master
@@ -56,7 +55,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       scheduled_ref: ${{ steps.get-scheduled-ref.outputs.scheduled_ref }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up matrix
         id: set-matrix
@@ -80,12 +79,11 @@ jobs:
         exclude:
         # TODO: Remove this exclusion once https://github.com/ACCESS-NRI/oasis3-mct/issues/41 is fixed
         - file: .github/build-ci/manifests/scheduled/gcc_mom_access-esm1.6.spack.yaml.j2
-    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-path: ${{ matrix.file }}
       spack-manifest-data-path: .github/build-ci/data/standard.json
       ref: ${{ needs.pre-master.outputs.scheduled_ref }}
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
-      # spack-packages-ref: main
-      # spack-config-ref: main
-      # spack-ref: releases/v0.22
+      # Default args (including explicit spack/spack-packages/spack-config versions)
+      # are specified in https://github.com/ACCESS-NRI/build-ci/tree/v3/.github/workflows#inputs

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -46,6 +46,7 @@ jobs:
       spack-manifest-data-path: .github/build-ci/data/standard.json
       ref: ${{ needs.pre-access-esm1p5.outputs.scheduled_ref }}
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
+      access-spack-packages-ref: 2026.07.013  # The @access-esm1.5 version for manifests is only available < 2026.08.000, so we are pinned here
       # Default args (including explicit spack/spack-packages/spack-config versions)
       # are specified in https://github.com/ACCESS-NRI/build-ci/tree/v3/.github/workflows#inputs
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -41,6 +41,7 @@ jobs:
         - file: .github/build-ci/manifests/scheduled/oneapi_mom_access-esm1.5.spack.yaml.j2
     uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
+      spack-manifest-repository-ref: access-esm1.5
       spack-manifest-path: ${{ matrix.file }}
       spack-manifest-data-path: .github/build-ci/data/standard.json
       ref: ${{ needs.pre-access-esm1p5.outputs.scheduled_ref }}


### PR DESCRIPTION
## Background

We missed the `scheduled.yml` file in our migration to `build-ci@v3` in https://github.com/ACCESS-NRI/MOM5/pull/70! I usually just `sed ... .github/workflows/ci.yml` for all repos, but that misses these types of files - whoops.

## The PR

* Update `build-ci` to `v3`, `actions/checkout` to `v7` 

## Testing

Tested via `workflow_dispatch` in https://github.com/ACCESS-NRI/MOM5/actions/runs/31980984161
